### PR TITLE
Update QueryTableParser.php

### DIFF
--- a/lib/QueryTableParser.php
+++ b/lib/QueryTableParser.php
@@ -53,10 +53,27 @@ class QueryTableParser {
             if (in_array(strtolower($token), $this->table_tokens)) {
 
                 $table = $this->get_next_token();
-
-                if (preg_match("/\w+/", $table)) {
-                    $table = str_replace('`', '', $table);
-                    $tables[$table]=1;
+                
+                #Handles old style joins
+                if (preg_match("/,/", $table)) {
+                    while (preg_match("/,/", $table)) {
+                        $table = str_replace(',', '', $table);
+                        if (preg_match("/\w+/", $table)) {
+                            $table = str_replace('`', '', $table);
+                            $tables[$table]=1;
+                        }
+                        $table = $this->get_next_token();
+                    }
+                    if (preg_match("/\w+/", $table)) {
+                        $table = str_replace('`', '', $table);
+                        $tables[$table]=1;
+                    }
+                }
+                else {
+                    if (preg_match("/\w+/", $table)) {
+                        $table = str_replace('`', '', $table);
+                        $tables[$table]=1;
+                    }
                 }
             }
         }


### PR DESCRIPTION
Updated parse to handle old style joins where the join key word isn't used an commas are used instead:

Example:
SELECT \* FROM tableA, tableB WHERE tableA.id = tableB.id;
VS.
SELECT \* FROM tableA JOIN tableB ON tableA.id = tableB.id;
