### PR TITLE
Remove proto + hostname in href to enable reverse proxying

### DIFF
--- a/lib/Helpers.php
+++ b/lib/Helpers.php
@@ -35,15 +35,7 @@ function get_var($name)
  */
 function site_url()
 {
-    if (isset($_SERVER['HTTPS']))
-    {
-        $proto = 'https://';
-    }
-    else
-    {
-        $proto = 'http://';
-    }
-    return $proto . $_SERVER['HTTP_HOST'] . $_SERVER['SCRIPT_NAME'];
+    return $_SERVER['SCRIPT_NAME'];
 }
 
 


### PR DESCRIPTION
Having the hostname in every href cause trouble reverse proxying since it'll always redirect on the original host. With this change it willsimply push the scriptname.
