### PR TITLE
Dynamic config

### DIFF
--- a/conf/datasource_localhost.inc.php
+++ b/conf/datasource_localhost.inc.php
@@ -1,0 +1,14 @@
+<?php
+$conf['datasources']['localhost'] = array(
+	'host'	=> 'localhost',
+	'port'	=> 3306,
+	'db'	=> 'slow_query_log',
+	'user'	=> 'root',
+	'password' => '',
+	'tables' => array(
+		'global_query_review' => 'fact',
+		'global_query_review_history' => 'dimension'
+	),
+	'source_type' => 'slow_query_log'
+);
+

--- a/conf/sample.config.inc.php
+++ b/conf/sample.config.inc.php
@@ -32,18 +32,10 @@
  * one you want to report on.
  *
  */
-$conf['datasources']['localhost'] = array(
-	'host'	=> 'localhost',
-	'port'	=> 3306,
-	'db'	=> 'slow_query_log',
-	'user'	=> 'root',
-	'password' => '',
-	'tables' => array(
-		'global_query_review' => 'fact',
-		'global_query_review_history' => 'dimension'
-	),
-	'source_type' => 'slow_query_log'
-);
+ 
+foreach(glob("conf/datasource_*.inc.php") as $datasource) {
+	require_once($datasource);
+}
 
 /**
  * If you're using Anemometer with MySQL 5.6's performance schema,


### PR DESCRIPTION
Moved localhost datasource definition out from sample.config.inc.php to datasource_localhost.inc.php and making sample.config.inc.php load configs automatically from conf/datasource_*.inc.php - this makes it very easy to mass deploy monitoring of multiple hosts via puppet.
