### PR TITLE
- Small tweak to cleanse the Query of /* ... */ style comments which …

### DIFF
--- a/lib/QueryExplain.php
+++ b/lib/QueryExplain.php
@@ -202,7 +202,7 @@ class QueryExplain {
      * @return MySQLi_Result    the result handle
      */
     private function explain_query() {
-        $Query = new QueryRewrite($this->query);
+		$Query = new QueryRewrite(preg_replace('/\/\*(.*)\*\//Uis', '', $this->query));
         $explain = $Query->asExplain();
 
         if (is_null($explain))


### PR DESCRIPTION
Small tweak to cleanse the Query of /\* ... */ style comments which break the query explain parser

(a bit of an edge case, I know, but our query building tool adds non-standard /\* ... */ style comments for query information, which seemed to collapse to nothing, breaking the queries.
