### PR TITLE
updates box setting in dev vagrant file to working box fix #157

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "chef/centos-6.5"
+  config.vm.box = "bento/centos-6.7"
   config.vm.provision :shell, :path => "bootstrap.sh"
   config.vm.network :forwarded_port, host: 8844, guest: 80
 


### PR DESCRIPTION
attempting to vagrant up on the dev vagrant breaks due to the virtualbox box image not being found. Just updated the Vagrant file to use the bento centos 6.7 for parity and functionality. 

`URL: ["https://atlas.hashicorp.com/chef/centos-6.5"]
Error: The requested URL returned error: 404 Not Found`

Tested: did a vagrant up and worked with that image, which is publicly viewable
https://atlas.hashicorp.com/bento/boxes/centos-6.7