### PR TITLE
Upgrading Vagrant image to Centos 7

### DIFF
--- a/vagrant/ISSUES.md
+++ b/vagrant/ISSUES.md
@@ -1,34 +1,15 @@
-#
+# Issues found during the migration
+
 
 ```
-Downloading VirtualBox Guest Additions ISO from http://download.virtualbox.org/virtualbox/4.3.36/VBoxGuestAdditions_4.3.36.iso
-Copy iso file /home/emanuel/.vagrant.d/tmp/VBoxGuestAdditions_4.3.36.iso into the box /tmp/VBoxGuestAdditions.iso
-mount: /dev/loop0 is write-protected, mounting read-only
-Installing Virtualbox Guest Additions 4.3.36 - guest version is unknown
-Verifying archive integrity... All good.
-Uncompressing VirtualBox 4.3.36 Guest Additions for Linux............
-VirtualBox Guest Additions installer
-Copying additional installer modules ...
-Installing additional modules ...
-Removing existing VirtualBox non-DKMS kernel modules[  OK  ]
-Building the VirtualBox Guest Additions kernel modules
-Building the main Guest Additions module[  OK  ]
-Building the shared folder support module[  OK  ]
-Building the OpenGL support module[  OK  ]
-Doing non-kernel setup of the Guest Additions[  OK  ]
-Starting the VirtualBox Guest Additions [  OK  ]
 Installing the Window System drivers
 Could not find the X.Org or XFree86 Window System, skipping.
 An error occurred during installation of VirtualBox Guest Additions 4.3.36. Some functionality may not work as intended.
 In most cases it is OK that the "Window System drivers" installation failed.
 Cleaning up downloaded VirtualBox Guest Additions ISO...
-==> default: Checking for guest additions in VM...
-==> default: Rsyncing folder: /home/emanuel/vagrant/ => /home/vagrant/sync
-==> default: Mounting shared folders...
-    default: /vagrant => /home/emanuel/vagrant
-==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
-==> default: flag to force provisioning. Provisioners marked to run always will still run.
 ```
+
+## Rsync issue
 
 ```
 There was an error when attempting to rsync a synced folder.
@@ -42,3 +23,5 @@ symlink has no referent: "/home/emanuel/vagrant/anemometer/anemometer"
 FATAL I/O ERROR: dying to avoid a --delete-during issue with a pre-3.0.7 receiver.
 rsync error: requested action not supported (code 4) at flist.c(1885) [sender=3.1.0]
 ```
+
+Forced installation of rsync 3.1.

--- a/vagrant/ISSUES.md
+++ b/vagrant/ISSUES.md
@@ -1,0 +1,44 @@
+#
+
+```
+Downloading VirtualBox Guest Additions ISO from http://download.virtualbox.org/virtualbox/4.3.36/VBoxGuestAdditions_4.3.36.iso
+Copy iso file /home/emanuel/.vagrant.d/tmp/VBoxGuestAdditions_4.3.36.iso into the box /tmp/VBoxGuestAdditions.iso
+mount: /dev/loop0 is write-protected, mounting read-only
+Installing Virtualbox Guest Additions 4.3.36 - guest version is unknown
+Verifying archive integrity... All good.
+Uncompressing VirtualBox 4.3.36 Guest Additions for Linux............
+VirtualBox Guest Additions installer
+Copying additional installer modules ...
+Installing additional modules ...
+Removing existing VirtualBox non-DKMS kernel modules[  OK  ]
+Building the VirtualBox Guest Additions kernel modules
+Building the main Guest Additions module[  OK  ]
+Building the shared folder support module[  OK  ]
+Building the OpenGL support module[  OK  ]
+Doing non-kernel setup of the Guest Additions[  OK  ]
+Starting the VirtualBox Guest Additions [  OK  ]
+Installing the Window System drivers
+Could not find the X.Org or XFree86 Window System, skipping.
+An error occurred during installation of VirtualBox Guest Additions 4.3.36. Some functionality may not work as intended.
+In most cases it is OK that the "Window System drivers" installation failed.
+Cleaning up downloaded VirtualBox Guest Additions ISO...
+==> default: Checking for guest additions in VM...
+==> default: Rsyncing folder: /home/emanuel/vagrant/ => /home/vagrant/sync
+==> default: Mounting shared folders...
+    default: /vagrant => /home/emanuel/vagrant
+==> default: Machine already provisioned. Run `vagrant provision` or use the `--provision`
+==> default: flag to force provisioning. Provisioners marked to run always will still run.
+```
+
+```
+There was an error when attempting to rsync a synced folder.
+Please inspect the error message below for more info.
+
+Host path: /home/emanuel/vagrant/
+Guest path: /home/vagrant/sync
+Command: rsync --verbose --archive --delete -z --copy-links --no-owner --no-group --rsync-path sudo rsync -e ssh -p 2222 -o StrictHostKeyChecking=no -o IdentitiesOnly=true -o UserKnownHostsFile=/dev/null -i '/home/emanuel/vagrant/.vagrant/machines/default/virtualbox/private_key' --exclude .vagrant/ /home/emanuel/vagrant/ vagrant@127.0.0.1:/home/vagrant/sync
+Error: Warning: Permanently added '[127.0.0.1]:2222' (ECDSA) to the list of known hosts.
+symlink has no referent: "/home/emanuel/vagrant/anemometer/anemometer"
+FATAL I/O ERROR: dying to avoid a --delete-during issue with a pre-3.0.7 receiver.
+rsync error: requested action not supported (code 4) at flist.c(1885) [sender=3.1.0]
+```

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -4,17 +4,15 @@ Reference:
 https://github.com/mitchellh/vagrant/issues/6497
 
 
-Added in the `Vagrantfile`:
+Added in the `Vagrantfile` the following line:
 
 ```
-config.vm.synced_folder ".", "/vagrant", type: "nfs"
+config.vm.synced_folder ".", "/vagrant"
 ```
 
 
-I thought it was: https://www.virtualbox.org/ticket/12879
 
-
-Solution was:
+Requirements:
 
 ```
 vagrant plugin install vagrant-vbguest

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,18 +1,31 @@
-## Migrated to Centos
+## Migrated to Centos7
 
+Reference:
 https://github.com/mitchellh/vagrant/issues/6497
 
-Adding:
+
+Added in the `Vagrantfile`:
 
 ```
 config.vm.synced_folder ".", "/vagrant", type: "nfs"
 ```
+
 
 I thought it was: https://www.virtualbox.org/ticket/12879
 
 
 Solution was:
 
+```
 vagrant plugin install vagrant-vbguest
+```
 
+## How to setup the vagrant machine
 
+```
+mkdir vagrant
+git clone git@github.com:3manuek/Anemometer.git anemometer
+ln -s anemometer/vagrant/Vagrantfile Vagrantfile
+ln -s anemometer/vagrant/bootstrap.sh bootstrap.sh
+vagrant up
+```

--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,0 +1,18 @@
+## Migrated to Centos
+
+https://github.com/mitchellh/vagrant/issues/6497
+
+Adding:
+
+```
+config.vm.synced_folder ".", "/vagrant", type: "nfs"
+```
+
+I thought it was: https://www.virtualbox.org/ticket/12879
+
+
+Solution was:
+
+vagrant plugin install vagrant-vbguest
+
+

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -10,7 +10,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   # please see the online documentation at vagrantup.com.
 
   # Every Vagrant virtual environment requires a box to build off of.
-  config.vm.box = "chef/centos-6.5"
+  config.vm.box = "centos/7"
   config.vm.provision :shell, :path => "bootstrap.sh"
   config.vm.network :forwarded_port, host: 8844, guest: 80
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -13,6 +13,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "centos/7"
   config.vm.provision :shell, :path => "bootstrap.sh"
   config.vm.network :forwarded_port, host: 8844, guest: 80
+  config.vm.synced_folder ".", "/vagrant"
 
   # The url from where the 'config.vm.box' box will be fetched if it
   # doesn't already exist on the user's system.

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -30,7 +30,7 @@ sed -i 's/;date.timezone\ \=.*/date.timezone\ \=\ UTC/g' /etc/php.ini
 
 # Creating symbolic links ocurred in permission issues.
 echo "Cloning anemometer"
-git clone https://github.com/3manuek/Anemometer.git $ANEMOMETER_FOLDER
+git clone https://github.com/box/Anemometer.git $ANEMOMETER_FOLDER
 mv ${ANEMOMETER_FOLDER}/conf/sample.config.inc.php ${ANEMOMETER_FOLDER}/conf/config.inc.php
 
 #'user'  => 'root',

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 sudo -s
 
+echo "Package installation; can take several minutes."
 # base packages, including percona mysql repo
 yum update -y
 yum install -y kernel-devel-`uname -r` gcc make perl bzip2
@@ -13,28 +14,14 @@ yum install -y httpd php php-mysql php-bcmath wget git
 wget http://mirror.symnds.com/distributions/gf/el/7/plus/x86_64/rsync-3.1.1-6.gf.el7.x86_64.rpm
 rpm -Uvh rsync-3.1.1-6.gf.el7.x86_64.rpm
 
-# install percona toolkit
 yum install -y perl-DBD-MySQL perl-Time-HiRes perl-IO-Socket-SSL
 wget -q "http://www.percona.com/redir/downloads/percona-toolkit/2.2.10/RPM/percona-toolkit-2.2.10-1.noarch.rpm"
 rpm -i percona-toolkit-2.2.10-1.noarch.rpm
 
-#sed -i 's/enforcing/disabled/g' /etc/sysconfig/selinux
+
+echo "Disabling SELinux"
 sed -i s/SELINUX=enforcing/SELINUX=disabled/g /etc/selinux/config
-
 setenforce 0
-
-systemctl start mysqld.service
-systemctl start httpd.service
-
-git clone https://github.com/3manuek/Anemometer.git anemometer
-
-# setup symlink for apache & install anemometer files
-#ln -s /vagrant/anemometer  /var/www/html/anemometer
-
-[[ ! -h  /var/www/html/anemometer ]] && ln -s /home/vagrant/anemometer /var/www/html/anemometer
-
-#mysql -u root < /vagrant/anemometer/install.sql
-mysql -u root < anemometer/mysql56-install.sql 2> /dev/null
 
 
 # create my.cnf for access
@@ -43,8 +30,27 @@ cat << EOF > /home/vagrant/.my.cnf
 user=root
 EOF
 
+
+echo "Starting services"
+systemctl start mysqld.service
+systemctl start httpd.service
+
+# Creating symbolic links ocurred in permission issues.
+echo "Cloning anemometer"
+git clone https://github.com/3manuek/Anemometer.git /var/www/html/anemometer
+
 # add cron for collection script
 cat << EOF > /home/vagrant/crontab
 */5 * * * * /vagrant/anemometer/scripts/anemometer_collect.sh --interval 15 --history-db-host localhost --defaults-file /home/vagrant/.my.cnf --history-defaults-file /home/vagrant/.my.cnf
 EOF
 crontab -u root /home/vagrant/crontab
+
+
+# setup symlink for apache & install anemometer files
+# ln -s /vagrant/anemometer  /var/www/html/anemometer
+
+# [[ ! -h  /var/www/html/anemometer ]] && ln -s /home/vagrant/anemometer /var/www/html/anemometer
+
+#mysql -u root < /vagrant/anemometer/install.sql
+echo "Installing DB ..."
+mysql -u root < anemometer/mysql56-install.sql 2> /dev/null

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -31,7 +31,7 @@ git clone https://github.com/3manuek/Anemometer.git anemometer
 # setup symlink for apache & install anemometer files
 #ln -s /vagrant/anemometer  /var/www/html/anemometer
 
-[[ ! -e  /var/www/html/anemometer ]] && ln -s /var/www/html/anemometer anemometer
+[[ ! -h  /var/www/html/anemometer ]] && ln -s /home/vagrant/anemometer /var/www/html/anemometer
 
 #mysql -u root < /vagrant/anemometer/install.sql
 mysql -u root < anemometer/mysql56-install.sql 2> /dev/null

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -2,6 +2,7 @@
 sudo -s 
 
 # base packages, including percona mysql repo
+yum install -y kernel-devel-`uname -r` gcc make perl bzip2
 yum install -y http://www.percona.com/downloads/percona-release/percona-release-0.0-1.x86_64.rpm
 yum install -y Percona-Server-client-56 Percona-Server-shared-56 Percona-Server-server-56
 yum install -y httpd php php-mysql php-bcmath wget git

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -3,23 +3,21 @@
 # base packages, including percona mysql repo
 yum install -y http://www.percona.com/downloads/percona-release/percona-release-0.0-1.x86_64.rpm
 yum install -y Percona-Server-client-56 Percona-Server-shared-56 Percona-Server-server-56
-yum install -y httpd php php-mysql php-bcmath
+yum install -y httpd php php-mysql php-bcmath wget
+# install percona toolkit
+yum install -y perl-DBD-MySQL perl-Time-HiRes perl-IO-Socket-SSL
+wget -q "http://www.percona.com/redir/downloads/percona-toolkit/2.2.10/RPM/percona-toolkit-2.2.10-1.noarch.rpm"
+rpm -i percona-toolkit-2.2.10-1.noarch.rpm
 
-# add init scripts & auto start
-chkconfig --levels 235 mysqld on
-/etc/init.d/mysql start
-chkconfig --levels 235 httpd on
-/etc/init.d/httpd start
+
+systemctl start mysqld.service
+systemctl start httpd.service
 
 # setup symlink for apache & install anemometer files
 ln -s /vagrant/anemometer  /var/www/html/anemometer 
 mysql -u root < /vagrant/anemometer/install.sql 
 mysql -u root < /vagrant/anemometer/mysql56-install.sql
 
-# install percona toolkit
-yum install -y perl-DBD-MySQL perl-Time-HiRes perl-IO-Socket-SSL
-wget -q "http://www.percona.com/redir/downloads/percona-toolkit/2.2.10/RPM/percona-toolkit-2.2.10-1.noarch.rpm"
-rpm -i percona-toolkit-2.2.10-1.noarch.rpm 
 
 # create my.cnf for access
 cat << EOF > /home/vagrant/.my.cnf

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -24,20 +24,24 @@ sed -i s/SELINUX=enforcing/SELINUX=disabled/g /etc/selinux/config
 setenforce 0
 
 
+sed -i 's/;date.timezone\ \=.*/date.timezone\ \=\ UTC/g' /etc/php.ini
+
+# Creating symbolic links ocurred in permission issues.
+echo "Cloning anemometer"
+git clone https://github.com/3manuek/Anemometer.git /var/www/html/anemometer
+mv /var/www/html/anemometer/conf/sample.config.inc.php /var/www/html/anemometer/conf/config.inc.php
+
+#'user'  => 'root',
+#'password' => '',
+#GRANT ALL ON slow_query_log.* TO 'anemometer'@'localhost' IDENTIFIED BY 'anemometer';
+
+
 # create my.cnf for access
 cat << EOF > /home/vagrant/.my.cnf
 [client]
 user=root
 EOF
 
-
-echo "Starting services"
-systemctl start mysqld.service
-systemctl start httpd.service
-
-# Creating symbolic links ocurred in permission issues.
-echo "Cloning anemometer"
-git clone https://github.com/3manuek/Anemometer.git /var/www/html/anemometer
 
 # add cron for collection script
 cat << EOF > /home/vagrant/crontab
@@ -50,6 +54,12 @@ crontab -u root /home/vagrant/crontab
 # ln -s /vagrant/anemometer  /var/www/html/anemometer
 
 # [[ ! -h  /var/www/html/anemometer ]] && ln -s /home/vagrant/anemometer /var/www/html/anemometer
+
+
+echo "Starting services"
+systemctl start mysqld.service
+systemctl start httpd.service
+
 
 #mysql -u root < /vagrant/anemometer/install.sql
 echo "Installing DB ..."

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 sudo -s
 
+ANEMOMETER_FOLDER=/var/www/html/anemometer
+
 echo "Package installation; can take several minutes."
 # base packages, including percona mysql repo
 yum update -y
@@ -28,8 +30,8 @@ sed -i 's/;date.timezone\ \=.*/date.timezone\ \=\ UTC/g' /etc/php.ini
 
 # Creating symbolic links ocurred in permission issues.
 echo "Cloning anemometer"
-git clone https://github.com/3manuek/Anemometer.git /var/www/html/anemometer
-mv /var/www/html/anemometer/conf/sample.config.inc.php /var/www/html/anemometer/conf/config.inc.php
+git clone https://github.com/3manuek/Anemometer.git $ANEMOMETER_FOLDER
+mv ${ANEMOMETER_FOLDER}/conf/sample.config.inc.php ${ANEMOMETER_FOLDER}/conf/config.inc.php
 
 #'user'  => 'root',
 #'password' => '',
@@ -63,4 +65,5 @@ systemctl start httpd.service
 
 #mysql -u root < /vagrant/anemometer/install.sql
 echo "Installing DB ..."
-mysql -u root < anemometer/mysql56-install.sql 2> /dev/null
+mysql -u root < ${ANEMOMETER_FOLDER}/install.sql 2> /dev/null
+mysql -u root < ${ANEMOMETER_FOLDER}/mysql56-install.sql 2> /dev/null

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,11 +1,18 @@
 #!/usr/bin/env bash
-sudo -s 
+sudo -s
 
 # base packages, including percona mysql repo
+yum update -y
 yum install -y kernel-devel-`uname -r` gcc make perl bzip2
 yum install -y http://www.percona.com/downloads/percona-release/percona-release-0.0-1.x86_64.rpm
 yum install -y Percona-Server-client-56 Percona-Server-shared-56 Percona-Server-server-56
 yum install -y httpd php php-mysql php-bcmath wget git
+
+# Rsync between 3.0 and 3.1 are not compatible
+# FATAL I/O ERROR: dying to avoid a --delete-during issue with a pre-3.0.7 receiver.
+wget http://mirror.symnds.com/distributions/gf/el/7/plus/x86_64/rsync-3.1.1-6.gf.el7.x86_64.rpm
+rpm -Uvh rsync-3.1.1-6.gf.el7.x86_64.rpm
+
 # install percona toolkit
 yum install -y perl-DBD-MySQL perl-Time-HiRes perl-IO-Socket-SSL
 wget -q "http://www.percona.com/redir/downloads/percona-toolkit/2.2.10/RPM/percona-toolkit-2.2.10-1.noarch.rpm"
@@ -22,11 +29,11 @@ systemctl start httpd.service
 git clone https://github.com/3manuek/Anemometer.git anemometer
 
 # setup symlink for apache & install anemometer files
-#ln -s /vagrant/anemometer  /var/www/html/anemometer 
+#ln -s /vagrant/anemometer  /var/www/html/anemometer
 
-[[ ! -e  /var/www/html/anemometer ]] && ln -s anemometer /var/www/html/anemometer 
+[[ ! -e  /var/www/html/anemometer ]] && ln -s /var/www/html/anemometer anemometer
 
-#mysql -u root < /vagrant/anemometer/install.sql 
+#mysql -u root < /vagrant/anemometer/install.sql
 mysql -u root < anemometer/mysql56-install.sql 2> /dev/null
 
 

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -64,19 +64,10 @@ cat << EOF > /home/vagrant/crontab
 EOF
 crontab -u root /home/vagrant/crontab
 
-
-# setup symlink for apache & install anemometer files
-# ln -s /vagrant/anemometer  /var/www/html/anemometer
-
-# [[ ! -h  /var/www/html/anemometer ]] && ln -s /home/vagrant/anemometer /var/www/html/anemometer
-
-
 echo "Starting services"
 systemctl start mysqld.service
 systemctl start httpd.service
 
-
-#mysql -u root < /vagrant/anemometer/install.sql
 echo "Installing DB ..."
 mysql -u root < ${ANEMOMETER_FOLDER}/install.sql 2> /dev/null
 mysql -u root < ${ANEMOMETER_FOLDER}/mysql56-install.sql 2> /dev/null

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -1,22 +1,32 @@
 #!/usr/bin/env bash
+sudo -s 
 
 # base packages, including percona mysql repo
 yum install -y http://www.percona.com/downloads/percona-release/percona-release-0.0-1.x86_64.rpm
 yum install -y Percona-Server-client-56 Percona-Server-shared-56 Percona-Server-server-56
-yum install -y httpd php php-mysql php-bcmath wget
+yum install -y httpd php php-mysql php-bcmath wget git
 # install percona toolkit
 yum install -y perl-DBD-MySQL perl-Time-HiRes perl-IO-Socket-SSL
 wget -q "http://www.percona.com/redir/downloads/percona-toolkit/2.2.10/RPM/percona-toolkit-2.2.10-1.noarch.rpm"
 rpm -i percona-toolkit-2.2.10-1.noarch.rpm
 
+#sed -i 's/enforcing/disabled/g' /etc/sysconfig/selinux
+sed -i s/SELINUX=enforcing/SELINUX=disabled/g /etc/selinux/config
+
+setenforce 0
 
 systemctl start mysqld.service
 systemctl start httpd.service
 
+git clone https://github.com/3manuek/Anemometer.git anemometer
+
 # setup symlink for apache & install anemometer files
-ln -s /vagrant/anemometer  /var/www/html/anemometer 
-mysql -u root < /vagrant/anemometer/install.sql 
-mysql -u root < /vagrant/anemometer/mysql56-install.sql
+#ln -s /vagrant/anemometer  /var/www/html/anemometer 
+
+[[ ! -e  /var/www/html/anemometer ]] && ln -s anemometer /var/www/html/anemometer 
+
+#mysql -u root < /vagrant/anemometer/install.sql 
+mysql -u root < anemometer/mysql56-install.sql 2> /dev/null
 
 
 # create my.cnf for access

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -6,7 +6,7 @@ ANEMOMETER_FOLDER=/var/www/html/anemometer
 echo "Package installation; can take several minutes."
 # base packages, including percona mysql repo
 yum update -y
-yum install -y kernel-devel-`uname -r` gcc make perl bzip2
+yum install -y kernel-devel-`uname -r` gcc make perl bzip2 perl-Digest-MD5
 yum install -y http://www.percona.com/downloads/percona-release/percona-release-0.0-1.x86_64.rpm
 yum install -y Percona-Server-client-56 Percona-Server-shared-56 Percona-Server-server-56
 yum install -y httpd php php-mysql php-bcmath wget git
@@ -42,6 +42,19 @@ mv ${ANEMOMETER_FOLDER}/conf/sample.config.inc.php ${ANEMOMETER_FOLDER}/conf/con
 cat << EOF > /home/vagrant/.my.cnf
 [client]
 user=root
+EOF
+
+cat << EOF > /etc/my.cnf
+[mysqld]
+datadir=/var/lib/mysql
+socket=/var/lib/mysql/mysql.sock
+symbolic-links=0
+sql_mode=NO_ENGINE_SUBSTITUTION,STRICT_TRANS_TABLES
+slow_query_log=1
+long_query_time=2
+[mysqld_safe]
+log-error=/var/log/mysqld.log
+pid-file=/var/run/mysqld/mysqld.pid
 EOF
 
 


### PR DESCRIPTION
The existent Vagrantfile will fail due that chef organization does not exists anymore. I moved the entire image to run on Centos7, from Centos org.
