### PR TITLE
Made datasource list scrollable (fixes #161)

### DIFF
--- a/css/bootstrap-combobox.css
+++ b/css/bootstrap-combobox.css
@@ -109,3 +109,9 @@
   max-height: 300px;
   overflow-y: auto;
 }
+
+.scrollable-menu {
+    height: auto;
+    max-height: 600px;
+    overflow-x: hidden;
+}

--- a/views/navbar.php
+++ b/views/navbar.php
@@ -21,7 +21,7 @@
                       <b class="caret"></b>
                       
                 </a>
-                <ul class="dropdown-menu">
+                <ul class="dropdown-menu scrollable-menu">
                   <?php foreach ($datasources as $ds) { ?> 
                     <li><a href="<?php echo site_url().'?action=report&datasource='.$ds; ?>"><?php echo $ds; ?></a></li>
                   <?php } ?>


### PR DESCRIPTION
Simple fix for making the datasource dropdown scrollable, add anothe css class to the dropdown menu. Added the css class to bootstrap-combobox.css
