### PR TITLE
Update AnemometerModel.php

### DIFF
--- a/lib/AnemometerModel.php
+++ b/lib/AnemometerModel.php
@@ -198,7 +198,11 @@ class AnemometerModel {
      */
     public function checksum_exists($checksum) {
         $checksum_field_name = $this->get_field_name('checksum');
-        $query = "SELECT `{$checksum_field_name}` FROM `{$this->fact_table}` WHERE `{$checksum_field_name}`=" . $this->mysqli->real_escape_string($checksum);
+        if ($checksum_field_name == 'DIGEST') {
+            $query = "SELECT `{$checksum_field_name}` FROM `{$this->fact_table}` WHERE `{$checksum_field_name}`='" . $this->mysqli->real_escape_string($checksum) . "'";
+        } else {
+            $query = "SELECT `{$checksum_field_name}` FROM `{$this->fact_table}` WHERE `{$checksum_field_name}`=" . $this->mysqli->real_escape_string($checksum);
+        }
         $result = $this->mysqli->query($query);
         check_mysql_error($result, $this->mysqli);
         if ($result->num_rows) {
@@ -227,7 +231,11 @@ class AnemometerModel {
                         }, array_keys($fields), array_values($fields)
                 )
         );
-        $sql .= " WHERE `{$checksum_field_name}`=" . $this->mysqli->real_escape_string($checksum);
+        if ($checksum_field_name == 'DIGEST') {
+            $sql .= " WHERE `{$checksum_field_name}`='" . $this->mysqli->real_escape_string($checksum) . "'";
+        } else {
+            $sql .= " WHERE `{$checksum_field_name}`=" . $this->mysqli->real_escape_string($checksum);
+        }
         $res = $this->mysqli->query($sql);
         // @todo ... fix this by making it a local method
         check_mysql_error($res, $this->mysqli);
@@ -241,7 +249,11 @@ class AnemometerModel {
      */
     public function get_query_by_checksum($checksum) {
         $checksum_field_name = $this->get_field_name('checksum');
-        $result = $this->mysqli->query("SELECT * FROM `{$this->fact_table}` WHERE `{$checksum_field_name}`={$checksum}");
+        if ($checksum_field_name == 'DIGEST') {
+            $result = $this->mysqli->query("SELECT * FROM `{$this->fact_table}` WHERE `{$checksum_field_name}`='{$checksum}'");
+        } else {
+            $result = $this->mysqli->query("SELECT * FROM `{$this->fact_table}` WHERE `{$checksum_field_name}`={$checksum}");
+        }
         check_mysql_error($result, $this->mysqli);
         if ($row = $result->fetch_assoc()) {
             return $row;
@@ -265,7 +277,11 @@ class AnemometerModel {
         {
             $table = $this->fact_table;
         }
-        $sql = "SELECT * FROM `{$table}` WHERE `{$checksum_field_name}`={$checksum} ORDER BY `{$time_field_name}` DESC LIMIT {$limit} OFFSET {$offset}";
+        if ($checksum_field_name == 'DIGEST') {
+            $sql = "SELECT * FROM `{$table}` WHERE `{$checksum_field_name}`='{$checksum}' ORDER BY `{$time_field_name}` DESC LIMIT {$limit} OFFSET {$offset}";
+        } else {
+            $sql = "SELECT * FROM `{$table}` WHERE `{$checksum_field_name}`={$checksum} ORDER BY `{$time_field_name}` DESC LIMIT {$limit} OFFSET {$offset}";
+        }
         return $this->mysqli->query($sql);
     }
 


### PR DESCRIPTION
Previous pull request #179 removed quotes from all values.  This included DIGEST which is a string type and requires the quotes.  I added a test for the field name and added back quotes when $checksum_field_name == 'DIGEST'.

This change is required to use Anemometer with performance_schema.  Without the change we receive this error: 1054
Unknown column 'e18098fcab5e42bba3e4b6b477bb27b3' in 'where clause'