### PR TITLE
Use char(32) for checksums instead of bigint unsigned

### DIFF
--- a/conf/sample.config.inc.php
+++ b/conf/sample.config.inc.php
@@ -345,7 +345,6 @@ $conf['reports']['slow_query_log'] = array(
 	'callbacks'     => array(
 		'table' => array(
 			'date'  => function ($x) { $type=''; if ( date('N',strtotime($x)) >= 6) { $type = 'weekend'; } return array($x,$type); },
-			'checksum' => function ($x) { return array(dec2hex($x), ''); }
 		)
 	)
 

--- a/docs/classes/Anemometer.html
+++ b/docs/classes/Anemometer.html
@@ -223,7 +223,6 @@ a CI installation (untested.)</p>
                         <section class="row-fluid private">
                             <section class="span4">
                                                                     <a href="../classes/Anemometer.html#method_setup_data_for_graph_search" class="">setup_data_for_graph_search()</a><br />
-                                                                    <a href="../classes/Anemometer.html#method_translate_checksum" class="">translate_checksum()</a><br />
                                                                     <a href="../classes/Anemometer.html#method_alert" class="">alert()</a><br />
                                                                     <a href="../classes/Anemometer.html#method_display_report_form" class="">display_report_form()</a><br />
                                                                     <a href="../classes/Anemometer.html#method_footer" class="">footer()</a><br />
@@ -748,40 +747,6 @@ or display an error message</em></p>
                                                     <tr>
                                 <td></td>
                                 <td>$data </td>
-                                <td></td>
-                            </tr>
-                                            </table>
-                
-                
-                				
-                            </article>
-        </div>
-        <aside class="span4 detailsbar">
-            <h1><i class="icon-arrow-down"></i></h1>
-                                                            <dl>
-                                                                            </dl>
-            <h2>Tags</h2>
-            <table class="table table-condensed">
-                                    <tr><td colspan="2"><em>None found</em></td></tr>
-                            </table>
-        </aside>
-    </div>
-
-                                    <div class="row-fluid">
-        <div class="span8 content class">
-            <a id="method_translate_checksum" name="method_translate_checksum" class="anchor"></a>
-            <article class="method">
-                <h3 class="private ">translate_checksum()</h3>
-                <a href="#source-view" role="button" class="pull-right btn" data-toggle="modal" style="font-size: 1.1em; padding: 9px 14px"><i class="icon-code"></i></a>
-                <pre class="signature" style="margin-right: 54px;">translate_checksum(  <span class="argument">$checksum</span>) </pre>
-                <p><em></em></p>
-                
-
-                                    <h4>Parameters</h4>
-                    <table class="table table-condensed table-hover">
-                                                    <tr>
-                                <td></td>
-                                <td>$checksum </td>
                                 <td></td>
                             </tr>
                                             </table>

--- a/docs/files/Anemometer.php.txt
+++ b/docs/files/Anemometer.php.txt
@@ -89,15 +89,12 @@ class Anemometer {
         } else if (get_var('dimension-pivot-'.$checksum_field_name) != null
                    and get_var("dimension-pivot-{$checksum_field_name}-use-values") != null) {
             $values = explode('|',get_var("dimension-pivot-{$checksum_field_name}-use-values"));
-            for ($i=0; $i<count($values); $i++) {
-                $values[$i] = $this->translate_checksum($values[$i]);
-            }
             $this->report_obj->set_pivot_values("dimension-pivot-{$checksum_field_name}", $values);
             //$_GET["dimension-pivot-{$checksum_field_name}"] = get_var('plot_field');
         }
 
         // translate the checksum field from possible hex value
-        $checksum = $this->translate_checksum(get_var("fact-{$checksum_field_name}"));
+        $checksum = get_var("fact-{$checksum_field_name}");
         if (isset($checksum))
         {
 //            print "setting checksum [$checksum]";
@@ -268,7 +265,7 @@ class Anemometer {
      */
     public function quicksearch() {
         $datasource = get_var('datasource');
-        $checksum = $this->translate_checksum(get_var('checksum'));
+        $checksum = get_var('checksum');
         $exists = $this->data_model->checksum_exists($checksum);
         if (!$exists) {
             $this->alert("Unknown checksum: {$checksum}");
@@ -334,7 +331,7 @@ class Anemometer {
         $this->header();
 
         $datasource = get_var('datasource');
-        $checksum = $this->translate_checksum(get_var('checksum'));
+        $checksum = get_var('checksum');
         $start = get_var('start') | 0;
         $rpp = get_var('rpp');
 
@@ -355,31 +352,6 @@ class Anemometer {
         $this->footer();
     }
 
-    private function translate_checksum($checksum)
-    {
-	if (!in_array($this->data_model->get_source_type(), array('slow_query_log','default')))
-	{
-		return $checksum;
-	}
-
-        if (preg_match('/^[0-9]+$/', $checksum))
-        {
-            return $checksum;
-        }
-        else if (preg_match('/^[0-9A-Fa-f]+$/', $checksum))
-        {
-            return $this->bchexdec($checksum);
-        }
-        else if (strlen($checksum) == 0)
-        {
-            return null;
-        }
-        else
-        {
-            throw new Exception("Invalid query checksum");
-        }
-    }
-
     /**
      * Display a specific query from its checksum value
      *
@@ -387,7 +359,7 @@ class Anemometer {
     public function show_query() {
         $this->header();
         $output = 'table';
-        $checksum = $this->translate_checksum(get_var('checksum'));
+        $checksum = get_var('checksum');
         $exists = $this->data_model->checksum_exists($checksum);
         if (!$exists) {
             $this->alert("Unknown checksum: {$checksum}");
@@ -524,7 +496,7 @@ class Anemometer {
      *
      */
     public function upd_query() {
-        $checksum = $this->translate_checksum(get_var('checksum'));
+        $checksum = get_var('checksum');
         $valid_actions = array('Review', 'Review and Update Comments', 'Update Comments', 'Clear Review');
         $submit = get_var('submit');
 
@@ -746,4 +718,3 @@ class Anemometer {
 }
 
 ?>
-

--- a/install.sql
+++ b/install.sql
@@ -5,7 +5,7 @@ USE slow_query_log;
 
 -- Create the global query review table
 CREATE TABLE `global_query_review` (
-  `checksum` bigint(20) unsigned NOT NULL,
+  `checksum` char(32) NOT NULL,
   `fingerprint` text NOT NULL,
   `sample` longtext NOT NULL,
   `first_seen` datetime DEFAULT NULL,
@@ -21,7 +21,7 @@ CREATE TABLE `global_query_review` (
 CREATE TABLE `global_query_review_history` (
   `hostname_max` varchar(64) NOT NULL,
   `db_max` varchar(64) DEFAULT NULL,
-  `checksum` bigint(20) unsigned NOT NULL,
+  `checksum` char(32) NOT NULL,
   `sample` longtext NOT NULL,
   `ts_min` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',
   `ts_max` datetime NOT NULL DEFAULT '0000-00-00 00:00:00',

--- a/lib/Anemometer.php
+++ b/lib/Anemometer.php
@@ -89,15 +89,12 @@ class Anemometer {
         } else if (get_var('dimension-pivot-'.$checksum_field_name) != null
                    and get_var("dimension-pivot-{$checksum_field_name}-use-values") != null) {
             $values = explode('|',get_var("dimension-pivot-{$checksum_field_name}-use-values"));
-            for ($i=0; $i<count($values); $i++) {
-                $values[$i] = $this->translate_checksum($values[$i]);
-            }
             $this->report_obj->set_pivot_values("dimension-pivot-{$checksum_field_name}", $values);
             //$_GET["dimension-pivot-{$checksum_field_name}"] = get_var('plot_field');
         }
 
         // translate the checksum field from possible hex value
-        $checksum = $this->translate_checksum(get_var("fact-{$checksum_field_name}"));
+        $checksum = get_var("fact-{$checksum_field_name}");
         if (isset($checksum))
         {
 //            print "setting checksum [$checksum]";
@@ -268,7 +265,7 @@ class Anemometer {
      */
     public function quicksearch() {
         $datasource = get_var('datasource');
-        $checksum = $this->translate_checksum(get_var('checksum'));
+        $checksum = get_var('checksum');
         $exists = $this->data_model->checksum_exists($checksum);
         if (!$exists) {
             $this->alert("Unknown checksum: {$checksum}");
@@ -334,7 +331,7 @@ class Anemometer {
         $this->header();
 
         $datasource = get_var('datasource');
-        $checksum = $this->translate_checksum(get_var('checksum'));
+        $checksum = get_var('checksum');
         $start = get_var('start') | 0;
         $rpp = get_var('rpp');
 
@@ -355,31 +352,6 @@ class Anemometer {
         $this->footer();
     }
 
-    private function translate_checksum($checksum)
-    {
-	if (!in_array($this->data_model->get_source_type(), array('slow_query_log','default')))
-	{
-		return $checksum;
-	}
-
-        if (preg_match('/^[0-9]+$/', $checksum))
-        {
-            return $checksum;
-        }
-        else if (preg_match('/^[0-9A-Fa-f]+$/', $checksum))
-        {
-            return $this->bchexdec($checksum);
-        }
-        else if (strlen($checksum) == 0)
-        {
-            return null;
-        }
-        else
-        {
-            throw new Exception("Invalid query checksum");
-        }
-    }
-
     /**
      * Display a specific query from its checksum value
      *
@@ -387,7 +359,7 @@ class Anemometer {
     public function show_query() {
         $this->header();
         $output = 'table';
-        $checksum = $this->translate_checksum(get_var('checksum'));
+        $checksum = get_var('checksum');
         $exists = $this->data_model->checksum_exists($checksum);
         if (!$exists) {
             $this->alert("Unknown checksum: {$checksum}");
@@ -524,7 +496,7 @@ class Anemometer {
      *
      */
     public function upd_query() {
-        $checksum = $this->translate_checksum(get_var('checksum'));
+        $checksum = get_var('checksum');
         $valid_actions = array('Review', 'Review and Update Comments', 'Update Comments', 'Clear Review');
         $submit = get_var('submit');
 

--- a/lib/AnemometerModel.php
+++ b/lib/AnemometerModel.php
@@ -198,7 +198,7 @@ class AnemometerModel {
      */
     public function checksum_exists($checksum) {
         $checksum_field_name = $this->get_field_name('checksum');
-        $query = "SELECT `{$checksum_field_name}` FROM `{$this->fact_table}` WHERE `{$checksum_field_name}`=" . $this->mysqli->real_escape_string($checksum);
+        $query = "SELECT `{$checksum_field_name}` FROM `{$this->fact_table}` WHERE `{$checksum_field_name}`='" . $this->mysqli->real_escape_string($checksum) . "'";
         $result = $this->mysqli->query($query);
         check_mysql_error($result, $this->mysqli);
         if ($result->num_rows) {
@@ -227,7 +227,7 @@ class AnemometerModel {
                         }, array_keys($fields), array_values($fields)
                 )
         );
-        $sql .= " WHERE `{$checksum_field_name}`=" . $this->mysqli->real_escape_string($checksum);
+        $sql .= " WHERE `{$checksum_field_name}`='" . $this->mysqli->real_escape_string($checksum) . "'";
         $res = $this->mysqli->query($sql);
         // @todo ... fix this by making it a local method
         check_mysql_error($res, $this->mysqli);
@@ -241,7 +241,7 @@ class AnemometerModel {
      */
     public function get_query_by_checksum($checksum) {
         $checksum_field_name = $this->get_field_name('checksum');
-        $result = $this->mysqli->query("SELECT * FROM `{$this->fact_table}` WHERE `{$checksum_field_name}`={$checksum}");
+        $result = $this->mysqli->query("SELECT * FROM `{$this->fact_table}` WHERE `{$checksum_field_name}`='" . $this->mysqli->real_escape_string($checksum) . "'");
         check_mysql_error($result, $this->mysqli);
         if ($row = $result->fetch_assoc()) {
             return $row;
@@ -265,7 +265,7 @@ class AnemometerModel {
         {
             $table = $this->fact_table;
         }
-        $sql = "SELECT * FROM `{$table}` WHERE `{$checksum_field_name}`={$checksum} ORDER BY `{$time_field_name}` DESC LIMIT {$limit} OFFSET {$offset}";
+        $sql = "SELECT * FROM `{$table}` WHERE `{$checksum_field_name}`='" . $this->mysqli->real_escape_string($checksum) . "' ORDER BY `{$time_field_name}` DESC LIMIT {$limit} OFFSET {$offset}";
         return $this->mysqli->query($sql);
     }
 


### PR DESCRIPTION
Starting from Percona Toolkit 3.0.11, the checksum function has been updated to use _char(32)_ datatype in the checksum field, against _bigint unsigned_ actually.

Other Pull Requests (#201) submitted the same change, but in an incomplete way and with errors.

This one has been tested and is valid (to the extent of my tests).